### PR TITLE
Allow to set URL to Faktory instance via FAKTORY_URL env variable

### DIFF
--- a/faktory_exporter.go
+++ b/faktory_exporter.go
@@ -26,7 +26,7 @@ const (
 )
 
 var (
-	faktoryURL       = kingpin.Flag("faktory.url", "URL of the faktory instance").Default("tcp://localhost:7419").String()
+	faktoryURL       = kingpin.Flag("faktory.url", "URL of the faktory instance").Default("tcp://localhost:7419").OverrideDefaultFromEnvar("FAKTORY_URL").String()
 	webListenAddress = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface").Default(":9386").String()
 	webMetricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics").Default("/metrics").String()
 )


### PR DESCRIPTION
Duplicated from https://github.com/praekeltfoundation/faktory_exporter/pull/3

# Context

In containerized world (especially in Kubernetes) it is very common pattern to pass secret values via environment variables without exposing them in command line arguments or elsewhere.

# What's inside

Ability to specify URL to faktory instance (including password) via `FAKTORY_URL` environment variable. 

# Kubernetes usage

Example of defining sidecar with exporter for Faktory server pod (see https://github.com/AdWerx/charts/pull/12 for real example of usage)

```yaml
# Somewhere deep in StatefulSet declaration
        - name: metrics-exporter
          image: "praekeltfoundation/faktory_exporter:notyetreleased"
          imagePullPolicy: Always
          env:
            - name: FAKTORY_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: faktory
                  key: password
            - name: FAKTORY_URL
              value: tcp://:$(FAKTORY_PASSWORD)@localhost:7419
```